### PR TITLE
OWNERS_ALIASES: Update Steering members

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,11 +1,11 @@
-# See the OWNERS docs at https://go.k8s.io/owners#owners_aliases
+# See the OWNERS docs: https://go.k8s.io/owners#owners_aliases
 
 aliases:
   steering-committee:
     - cblecker
-    - derekwaynecarr
     - dims
+    - justaugustus
     - liggitt
     - mrbobbytables
-    - nikhita
     - parispittman
+    - tpepper


### PR DESCRIPTION
Part of https://github.com/kubernetes/steering/issues/219.

Emeritus:
- @nikhita 
- @derekwaynecarr 

Returning:
- @parispittman 
- @cblecker 

New:
- @justaugustus 
- @tpepper 

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @cblecker @mrbobbytables 
cc: @kubernetes/steering-committee 