### PR TITLE
steering: Onboard/Offboard members after 2023 elections

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,10 +2,10 @@
 
 aliases:
   steering-committee:
+    - BenTheElder
     - cblecker
-    - dims
     - justaugustus
-    - liggitt
     - mrbobbytables
+    - palnabarun
     - parispittman
     - tpepper

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,10 +10,10 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
+BenTheElder
 cblecker
-derekwaynecarr
-dims
-lachie83
-nikhita
+justaugustus
+mrbobbytables
+palnabarun
 parispittman
-spiffxp
+tpepper


### PR DESCRIPTION
(Part of https://github.com/kubernetes/steering/issues/256)

- Update aliases post 2023 steering elections
- update SECURITY_CONTACTS

/cc: @kubernetes/steering-committee 