### PR TITLE
Update Steering members following 2023 election cycle

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,9 +3,9 @@
 aliases:
   steering-committee:
     - BenTheElder
-    - cblecker
-    - cpanato
     - justaugustus
     - mrbobbytables
+    - pacoxu
     - palnabarun
-    - tpepper
+    - pohly
+    - soltysh


### PR DESCRIPTION
(Part of https://github.com/kubernetes/steering/issues/273.)

Add:

    Maciej Szulik - @soltysh
    Paco Xu 徐俊杰 - @pacoxu
    Patrick Ohly - @pohly

Remove:

    Carlos Tadeu Panato Jr. - @cpanato
    Christoph Blecker - @cblecker
    Tim Pepper - @tpepper

/assign @mrbobbytables @BenTheElder @palnabarun
cc: https://github.com/orgs/kubernetes/teams/steering-committee